### PR TITLE
convert to AndroidX/Capacitor 2.x

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,23 +1,29 @@
+ext {
+    junitVersion =  project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.12'
+    androidxJunitVersion =  project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.1'
+    androidxEspressoCoreVersion =  project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.2.0'
+}
+
 buildscript {
     repositories {
         jcenter()
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:4.0.1'
     }
 }
 
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 28
     defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 28
+        minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 21
+        targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 28
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     buildTypes {
         release {
@@ -40,9 +46,9 @@ repositories {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-    implementation 'com.android.support:appcompat-v7:28.0.0'
+    testImplementation "junit:junit:$junitVersion"
+    androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
+    androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
+    implementation 'androidx.appcompat:appcompat:1.0.0'
 }
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -15,3 +15,10 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+# AndroidX package structure to make it clearer which packages are bundled with the
+# Android operating system, and which are packaged with your app's APK
+# https://developer.android.com/topic/libraries/support-library/androidx-rn
+android.useAndroidX=true
+# Automatically convert third-party libraries to use AndroidX
+android.enableJetifier=true

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Dec 01 12:41:00 CST 2017
+#Thu Sep 10 14:30:47 EDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/android/src/main/res/layout/bridge_layout_main.xml
+++ b/android/src/main/res/layout/bridge_layout_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -12,4 +12,4 @@
         android:layout_width="fill_parent"
         android:layout_height="fill_parent" />
 
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,29 +5,29 @@
   "requires": true,
   "dependencies": {
     "@capacitor/android": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-1.3.0.tgz",
-      "integrity": "sha512-b+x15Sr4hOHUe45CaS2Xh6yc0zTjamo3eF0Wpra/rsh6gOwoI4bBRqwvKLeWsQRK1zakClfoFUSgpRWCAPASGw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-2.4.1.tgz",
+      "integrity": "sha512-y2KHTuD1SPiibYou8x84Aio54ZyG9LWNCoIcrjgiFM8FlIDdp2FuW4yP17KA8ORDfj37yWI+IRzKa+t/M7Jy3Q==",
       "dev": true
     },
     "@capacitor/core": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-1.3.0.tgz",
-      "integrity": "sha512-cVllg+OaYAPCsWOOOuMDqIk0tqjTH1QEBNgTKhAwLJraYy0w5CziUW5gtcmKXTRqD3dzUlHjx1emCKXrg0DACg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-2.4.1.tgz",
+      "integrity": "sha512-/OTDYTztAri04SNC+pIsSiIVG8ryjKkt3kG+aupoiHI1xankLJxGbcw5Z3aVZmhmMmJpk2nda2LC9Kc3Y0bA2w==",
       "requires": {
         "tslib": "^1.9.0"
       }
     },
     "@capacitor/ios": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-1.3.0.tgz",
-      "integrity": "sha512-iRFM1uMvlFS/N/6GJ735uE4OzjyrxDNPb8+OBUyRqmL7j/XBSv1mjKG5gpk2zWIbj/sXWWBHwXleuBsDIG7Fpg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-2.4.1.tgz",
+      "integrity": "sha512-Q1PfO67zn2668Gu9OYY2v02TuB20E530HHfe28wrK9X1Jy5jRFl1ZUr3epCkaB4XJQeGqM42oACO+BwURNAW5Q==",
       "dev": true
     },
     "tslib": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
     },
     "typescript": {
       "version": "3.7.2",


### PR DESCRIPTION
This PR updates the Android build to match Capacitor 2.x plugin style and upgrades it to use AndroidX.

I ran into a crash on Android and realized it was after I added this plugin.  I found [this comment on your other open pr](https://github.com/capacitor-community/keep-awake/pull/1) and figured I'd give the Android Studio automated upgrade a try, and it worked just fine.  I then tweaked a few things to match the way a newly-generated Capacitor plugin is formatted (using variables and such).
