### PR TITLE
docs: add copyright year and holder to the license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) COPYRIGHT_YEAR COPYRIGHT_HOLDER
+Copyright (c) 2019 The keep-awake developers.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The LICENSE was missing a copyright year and a name. This PR adds them.