### PR TITLE
feat: add `isKeptAwake` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ const isSupported = async () => {
 * [`keepAwake()`](#keepawake)
 * [`allowSleep()`](#allowsleep)
 * [`isSupported()`](#issupported)
+* [`isKeptAwake()`](#iskeptawake)
 * [Interfaces](#interfaces)
 
 </docgen-index>
@@ -108,6 +109,19 @@ Whether keep awake is supported or not.
 --------------------
 
 
+### isKeptAwake()
+
+```typescript
+isKeptAwake() => Promise<IsKeptAwakeResult>
+```
+
+Check if the device is kept awake.
+
+**Returns:** <code>Promise&lt;<a href="#iskeptawakeresult">IsKeptAwakeResult</a>&gt;</code>
+
+--------------------
+
+
 ### Interfaces
 
 
@@ -116,6 +130,13 @@ Whether keep awake is supported or not.
 | Prop              | Type                 |
 | ----------------- | -------------------- |
 | **`isSupported`** | <code>boolean</code> |
+
+
+#### IsKeptAwakeResult
+
+| Prop              | Type                 |
+| ----------------- | -------------------- |
+| **`isKeptAwake`** | <code>boolean</code> |
 
 </docgen-api>
 

--- a/README.md
+++ b/README.md
@@ -52,10 +52,14 @@ const allowSleep = async () => {
   await KeepAwake.allowSleep();
 };
 
-
 const isSupported = async () => {
   const result = await KeepAwake.isSupported();
   return result.isSupported;
+};
+
+const isKeptAwake = async () => {
+  const result = await KeepAwake.isKeptAwake();
+  return result.isKeptAwake;
 };
 ```
 

--- a/android/src/main/java/com/getcapacitor/community/keepawake/KeepAwakePlugin.java
+++ b/android/src/main/java/com/getcapacitor/community/keepawake/KeepAwakePlugin.java
@@ -15,13 +15,10 @@ public class KeepAwakePlugin extends Plugin {
     public void keepAwake(final PluginCall call) {
         getBridge()
             .executeOnMainThread(
-                new Runnable() {
-                    @Override
-                    public void run() {
-                        Window window = getActivity().getWindow();
-                        window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
-                        call.resolve();
-                    }
+                () -> {
+                    Window window = getActivity().getWindow();
+                    window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+                    call.resolve();
                 }
             );
     }
@@ -30,13 +27,10 @@ public class KeepAwakePlugin extends Plugin {
     public void allowSleep(final PluginCall call) {
         getBridge()
             .executeOnMainThread(
-                new Runnable() {
-                    @Override
-                    public void run() {
-                        Window window = getActivity().getWindow();
-                        window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
-                        call.resolve();
-                    }
+                () -> {
+                    Window window = getActivity().getWindow();
+                    window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+                    call.resolve();
                 }
             );
     }

--- a/android/src/main/java/com/getcapacitor/community/keepawake/KeepAwakePlugin.java
+++ b/android/src/main/java/com/getcapacitor/community/keepawake/KeepAwakePlugin.java
@@ -47,4 +47,21 @@ public class KeepAwakePlugin extends Plugin {
         ret.put("isSupported", true);
         call.resolve(ret);
     }
+
+    @PluginMethod
+    public void isKeptAwake(final PluginCall call) {
+        getBridge()
+            .executeOnMainThread(
+                () -> {
+                    // use the "bitwise and" operator to check if FLAG_KEEP_SCREEN_ON is on or off
+                    // credits: https://stackoverflow.com/a/24214209/9979122
+                    int flags = getActivity().getWindow().getAttributes().flags;
+                    boolean isKeptAwake = (flags & WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON) != 0;
+
+                    JSObject ret = new JSObject();
+                    ret.put("isKeptAwake", isKeptAwake);
+                    call.resolve(ret);
+                }
+            );
+    }
 }

--- a/ios/Plugin/KeepAwakePlugin.m
+++ b/ios/Plugin/KeepAwakePlugin.m
@@ -7,4 +7,5 @@ CAP_PLUGIN(KeepAwakePlugin, "KeepAwake",
            CAP_PLUGIN_METHOD(keepAwake, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(allowSleep, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(isSupported, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(isKeptAwake, CAPPluginReturnPromise);
 )

--- a/ios/Plugin/KeepAwakePlugin.swift
+++ b/ios/Plugin/KeepAwakePlugin.swift
@@ -31,4 +31,12 @@ public class KeepAwakePlugin: CAPPlugin {
             "isSupported": true
         ])
     }
+
+    @objc func isKeptAwake(_ call: CAPPluginCall) {
+        DispatchQueue.main.async {
+            call.resolve([
+                "isKeptAwake": UIApplication.shared.isIdleTimerDisabled
+            ])
+        }
+    }
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -11,8 +11,16 @@ export interface KeepAwakePlugin {
    * Whether keep awake is supported or not.
    */
   isSupported(): Promise<IsSupportedResult>;
+  /**
+   * Check if the device is kept awake.
+   */
+  isKeptAwake(): Promise<IsKeptAwakeResult>;
 }
 
 export interface IsSupportedResult {
   isSupported: boolean;
+}
+
+export interface IsKeptAwakeResult {
+  isKeptAwake: boolean;
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,6 +1,10 @@
 import { WebPlugin } from '@capacitor/core';
 
-import type { IsSupportedResult, KeepAwakePlugin } from './definitions';
+import type {
+  IsKeptAwakeResult,
+  IsSupportedResult,
+  KeepAwakePlugin,
+} from './definitions';
 
 export class KeepAwakeWeb extends WebPlugin implements KeepAwakePlugin {
   private wakeLock: WakeLockSentinel | null = null;
@@ -27,6 +31,16 @@ export class KeepAwakeWeb extends WebPlugin implements KeepAwakePlugin {
   public async isSupported(): Promise<IsSupportedResult> {
     const result = {
       isSupported: this._isSupported,
+    };
+    return result;
+  }
+
+  public async isKeptAwake(): Promise<IsKeptAwakeResult> {
+    if (!this._isSupported) {
+      this.throwUnsupportedError();
+    }
+    const result = {
+      isKeptAwake: !!this.wakeLock,
     };
     return result;
   }


### PR DESCRIPTION
Closes #17

This PR implement `isKeptAwake()` method to check if the device is kept awake.

I also refactor some code in android by replacing Runnable with lambda expression.
Ideally, the code should be fairly concise:

```java
    @PluginMethod
    public void keepAwake(final PluginCall call) {
        getBridge().executeOnMainThread(() -> {
            Window window = getActivity().getWindow();
            window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
            call.resolve();
        });
    }
```

However, Prettier decided to go wild and add more indentation levels 😂

```java
    @PluginMethod
    public void keepAwake(final PluginCall call) {
        getBridge()
            .executeOnMainThread(
                () -> {
                    Window window = getActivity().getWindow();
                    window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
                    call.resolve();
                }
            );
    }
```