### PR TITLE
fix: AGP 9.0 no longer supports `proguard-android.txt`

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,7 +30,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     lintOptions {


### PR DESCRIPTION
## Summary

Switch the Android library release config to `getDefaultProguardFile("proguard-android-optimize.txt")`.

## Why

Android Gradle Plugin 9 rejects `proguard-android.txt` because it bundles `-dontoptimize`. This causes project configuration to fail during Android Studio / Gradle project sync.

## Validation

- local Gradle sync on a downstream app using this plugin now gets past project configuration under Gradle 9.3.1 / AGP 8.13.0
